### PR TITLE
Removed "Email Header analysis" heading and moved the logo to the top

### DIFF
--- a/Promptbook samples/Network URI Encoded Analysis.md
+++ b/Promptbook samples/Network URI Encoded Analysis.md
@@ -1,3 +1,5 @@
+![Security CoPilot Logo](https://github.com/Azure/Copilot-For-Security/blob/main/Images/ic_fluent_copilot_64_64%402x.png)
+
 # Network Analysis - URI Request
 
 Inspired by [GreyNoise Sift](https://www.greynoise.io/blog/introducing-sift-automated-threat-hunting) and the possibilities to help in a number of areas where Layers 4-7 Web traffic is captured in SIEM and may need further analysis. Whether analyzing a URI, web traffic received, or using a Natural Language Prompt to KQL to provide further insights from Azure Web App Firewall among other use cases.
@@ -5,8 +7,8 @@ Inspired by [GreyNoise Sift](https://www.greynoise.io/blog/introducing-sift-auto
 
 Disclaimer: Please know these are sample prompts and are subject to Change
 
-![Security CoPilot Logo](https://github.com/Azure/Copilot-For-Security/blob/main/Images/ic_fluent_copilot_64_64%402x.png)
-# Email Header analysis 
+
+
 
 **Required plugins** : Microsoft Defender Threat intelligence, Microsoft Defender XDR
 


### PR DESCRIPTION
Removed "Email Header analysis" heading (assuming copy paste error?) and moved the logo to the top