### PR TITLE
LogicApp Link Update

### DIFF
--- a/Logic Apps/Readme.md
+++ b/Logic Apps/Readme.md
@@ -1,6 +1,6 @@
 ![Copilot for Security Overview](https://github.com/Azure/Copilot-For-Security/blob/main/Images/ic_fluent_copilot_64_64%402x.png)
 # Microsoft Copilot for Security Logic Apps
-Documentation : https://learn.microsoft.com/en-us/security-copilot/connector_logicapp
+Documentation : https://learn.microsoft.com/en-us/copilot/security/connector-logicapp
 
 The Microsoft Copilot for Security Logic Apps connector allows you to call into Microsoft Copilot for Security from a Logic Apps workflow. This document provides an introduction to the new connector actions you can leverage as well as sample use cases you can deploy to automate investigations such as on Sentinel incidents, email phishing, and others.
 


### PR DESCRIPTION
The link available earlier was providing a 404 error message. Updated the link to a working one.