### PR TITLE
Update eDiscovery_OAuth_API_manifest.yaml

### DIFF
--- a/Plugins/Community Based Plugins/Purview/eDiscovery/eDiscovery_OAuth_API_manifest.yaml
+++ b/Plugins/Community Based Plugins/Purview/eDiscovery/eDiscovery_OAuth_API_manifest.yaml
@@ -15,4 +15,4 @@ Descriptor:
 SkillGroups:
   - Format: API
     Settings:
-      OpenApiSpecUrl: https://raw.githubusercontent.com/samitks77/Copilot-For-Security/refs/heads/main/Plugins/Community%20Based%20Plugins/Purview/eDiscovery/eDiscovery_API_Plugin.yaml
+      OpenApiSpecUrl: https://raw.githubusercontent.com/Azure/Copilot-For-Security/refs/heads/main/Plugins/Community%20Based%20Plugins/Purview/eDiscovery/eDiscovery_API_Plugin.yaml


### PR DESCRIPTION
Updated OpenApiSpecUrl in "Plugins/Community Based Plugins/Purview/eDiscovery/eDiscovery_OAuth_API_manifest.yaml" to correct one in main github repo to: https://raw.githubusercontent.com/Azure/Copilot-For-Security/refs/heads/main/Plugins/Community%20Based%20Plugins/Purview/eDiscovery/eDiscovery_API_Plugin.yaml